### PR TITLE
pkg-config: re-enable libfmt.so, add it to the public dependencies

### DIFF
--- a/src/libs/recordings/meson.build
+++ b/src/libs/recordings/meson.build
@@ -58,7 +58,7 @@ pkg.generate(
     subdirs: 'oopetris',
     extra_cflags: recordings_dep_compile_args,
     variables: ['compiler=' + pkg_cpp_compiler, 'cpp_stdlib=' + pkg_cpp_stdlib],
-    requires: ['oopetris-core'],
+    requires: ['oopetris-core', 'fmt'],
 )
 
 # setting this to strings, so += {...} gets detected as an error, if it is done after that

--- a/tools/dependencies/meson.build
+++ b/tools/dependencies/meson.build
@@ -39,8 +39,6 @@ if (
     and (host_machine.system() == 'switch' or host_machine.system() == '3ds')
 )
     fmt_use_header_only = true
-elif not build_application
-    fmt_use_header_only = true
 endif
 
 if fmt_use_header_only


### PR DESCRIPTION
pkg-config: re-enable libfmt.so, add it to the public dependencies