### PR TITLE
CI: refactor the installer

### DIFF
--- a/.github/workflows/installer.yml
+++ b/.github/workflows/installer.yml
@@ -30,12 +30,6 @@ jobs:
         run: |
           pip install meson
 
-      - name: Configure
-        run: meson setup build -Dbuildtype=release -Ddefault_library=shared -Dbuild_installer=true
-
-      - name: Build
-        run: meson compile -C build
-
       - name: Download EnVar plugin for NSIS
         uses: carlosperate/download-file-action@v2
         with:
@@ -46,8 +40,13 @@ jobs:
       - name: Extract EnVar plugin
         run: 7z x "-oC:/Program Files (x86)/NSIS" "${{ github.workspace }}/envar_plugin.zip"
 
-      - name: Build installer (Windows)
+      - name: Configure
+        run: meson setup build -Dbuildtype=release -Ddefault_library=shared -Dbuild_installer=true
+
+      - name: Build installer
         run: |
+          meson compile -C build
+          meson install -C build --tags runtime --destdir "dynamic_libraries" 
           meson compile -C build windows_installer
 
       - name: Upload artifacts - Windows

--- a/meson.build
+++ b/meson.build
@@ -9,7 +9,6 @@ project(
         'strip': true,
         'cpp_std': ['c++23', 'c++latest', 'vc++latest', 'c++20'],
         'b_ndebug': 'if-release',
-
     },
     version: '0.5.6',
 )

--- a/platforms/build-android.sh
+++ b/platforms/build-android.sh
@@ -264,6 +264,7 @@ for INDEX in "${ARCH_KEYS_INDEX[@]}"; do
 
             # fix an compile time error since openssl 3.1.0 >
             # see https://github.com/android/ndk/issues/1992
+            # see https://github.com/openssl/openssl/pull/22181
             # Apply patch that fixes the armcap instruction
 
             # sed -e '/[.]hidden.*OPENSSL_armcap_P/d; /[.]extern.*OPENSSL_armcap_P/ {p; s/extern/hidden/ }' -i -- crypto/*arm*pl crypto/*/asm/*arm*pl

--- a/src/executables/meson.build
+++ b/src/executables/meson.build
@@ -83,7 +83,10 @@ if build_application
                         '-DPROJECT_SOURCE_DIR='
                         + meson.project_source_root(),
                         '-DPROJECT_BUILD_DIR=' + meson.project_build_root(),
-                        '-DDYNAMIC_LIBRARIES_DIR=' + (meson.project_build_root() / 'dynamic_libraries' / get_option('bindir')),
+                        '-DDYNAMIC_LIBRARIES_DIR='
+                        + (
+                            meson.project_build_root() / 'dynamic_libraries' / get_option('bindir')
+                        ),
                         nsis_script,
                     ],
                     depends: [oopetris_exe, oopetris_recordings_utility_exe],

--- a/src/executables/meson.build
+++ b/src/executables/meson.build
@@ -83,6 +83,7 @@ if build_application
                         '-DPROJECT_SOURCE_DIR='
                         + meson.project_source_root(),
                         '-DPROJECT_BUILD_DIR=' + meson.project_build_root(),
+                        '-DDYNAMIC_LIBRARIES_DIR=' + (meson.project_build_root() / 'dynamic_libraries' / get_option('bindir')),
                         nsis_script,
                     ],
                     depends: [oopetris_exe, oopetris_recordings_utility_exe],

--- a/subprojects/packagefiles/SDL2_image-2.6.3_install.diff
+++ b/subprojects/packagefiles/SDL2_image-2.6.3_install.diff
@@ -1,0 +1,12 @@
+diff --git a/meson.build b/meson.build
+index 728eea8..221edf9 100644
+--- a/meson.build
++++ b/meson.build
+@@ -153,6 +153,7 @@ sdl2_image_lib = library(
+   objc_args: full_library_args,
+   dependencies: deps,
+   gnu_symbol_visibility: 'hidden',
++  install: true
+ )
+ 
+ depinc = include_directories('.')

--- a/subprojects/packagefiles/discord_game_sdk/cpp/meson.build
+++ b/subprojects/packagefiles/discord_game_sdk/cpp/meson.build
@@ -93,6 +93,15 @@ discord_lib_c = c.find_library(
 
 if discord_lib_c.found()
     lib_deps += discord_lib_c
+
+    if c.get_id() == 'msvc'
+
+        install_data(
+            meson.project_source_root() / lib_dir / lib_name,
+            install_dir: get_option('bindir'),
+        )
+    endif
+
 else
     lib_deps += c.find_library(
         lib_name,

--- a/subprojects/sdl2_image.wrap
+++ b/subprojects/sdl2_image.wrap
@@ -9,5 +9,9 @@ patch_hash = 1741274f30b5b88299b2588a498a54a4203861ec1fa64c3bf99b359a6b618354
 source_fallback_url = https://github.com/mesonbuild/wrapdb/releases/download/sdl2_image_2.6.3-2/SDL2_image-2.6.3.tar.gz
 wrapdb_version = 2.6.3-2
 
+# TODO: remove once this is merged inot the wrapdb
+# see https://github.com/mesonbuild/wrapdb/pull/1737
+diff_files = SDL2_image-2.6.3_install.diff
+
 [provide]
 sdl2_image = sdl2_image_dep

--- a/subprojects/sdl2_mixer.wrap
+++ b/subprojects/sdl2_mixer.wrap
@@ -3,11 +3,11 @@ directory = SDL2_mixer-2.6.2
 source_url = https://www.libsdl.org/projects/SDL_mixer/release/SDL2_mixer-2.6.2.tar.gz
 source_filename = SDL2_mixer-2.6.2.tar.gz
 source_hash = 8cdea810366decba3c33d32b8071bccd1c309b2499a54946d92b48e6922aa371
-patch_filename = sdl2_mixer_2.6.2-3_patch.zip
-patch_url = https://wrapdb.mesonbuild.com/v2/sdl2_mixer_2.6.2-3/get_patch
-patch_hash = 194dcf9e025a864e0209ad290d1fca23f4fe058ae70d4ecdc342113cea0a48fb
-source_fallback_url = https://github.com/mesonbuild/wrapdb/releases/download/sdl2_mixer_2.6.2-3/SDL2_mixer-2.6.2.tar.gz
-wrapdb_version = 2.6.2-3
+patch_filename = sdl2_mixer_2.6.2-4_patch.zip
+patch_url = https://wrapdb.mesonbuild.com/v2/sdl2_mixer_2.6.2-4/get_patch
+patch_hash = 127025fa0666dd3ea66fb7c334182c393a748fb78810c6a44cdc1a85d619d934
+source_fallback_url = https://github.com/mesonbuild/wrapdb/releases/download/sdl2_mixer_2.6.2-4/SDL2_mixer-2.6.2.tar.gz
+wrapdb_version = 2.6.2-4
 
 [provide]
 sdl2_mixer = sdl2_mixer_dep

--- a/subprojects/sdl2_ttf.wrap
+++ b/subprojects/sdl2_ttf.wrap
@@ -3,11 +3,11 @@ directory = SDL2_ttf-2.20.1
 source_url = https://www.libsdl.org/projects/SDL_ttf/release/SDL2_ttf-2.20.1.tar.gz
 source_filename = SDL2_ttf-2.20.1.tar.gz
 source_hash = 78cdad51f3cc3ada6932b1bb6e914b33798ab970a1e817763f22ddbfd97d0c57
-patch_filename = sdl2_ttf_2.20.1-3_patch.zip
-patch_url = https://wrapdb.mesonbuild.com/v2/sdl2_ttf_2.20.1-3/get_patch
-patch_hash = dcbe819e2731c9546c29b766ba1803301a565cf7f07e6133dc2499195f47cf04
-source_fallback_url = https://github.com/mesonbuild/wrapdb/releases/download/sdl2_ttf_2.20.1-3/SDL2_ttf-2.20.1.tar.gz
-wrapdb_version = 2.20.1-3
+patch_filename = sdl2_ttf_2.20.1-4_patch.zip
+patch_url = https://wrapdb.mesonbuild.com/v2/sdl2_ttf_2.20.1-4/get_patch
+patch_hash = 44311aba31c9d5a3366101e5afd439a1d95e64d2079e9d5487e4d0790b6858f1
+source_fallback_url = https://github.com/mesonbuild/wrapdb/releases/download/sdl2_ttf_2.20.1-4/SDL2_ttf-2.20.1.tar.gz
+wrapdb_version = 2.20.1-4
 
 [provide]
 sdl2_ttf = sdl2_ttf_dep

--- a/tools/install/meson.build
+++ b/tools/install/meson.build
@@ -5,6 +5,7 @@ if build_application
     install_subdir(
         meson.project_source_root() / 'assets',
         install_dir: 'share/oopetris',
+        install_tag: 'assets',
         exclude_files: ['oopetris.desktop.in', 'OOPetris.svg', 'recordings.magic'],
         exclude_directories: ['icon'],
     )
@@ -38,6 +39,7 @@ if build_application
                 input: [oopetris_magic_file, magic_file],
                 output: 'magic',
                 install_dir: magic_dir,
+                install_tag: 'other',
             )
 
         else
@@ -45,6 +47,7 @@ if build_application
             install_data(
                 oopetris_magic_file,
                 install_dir: magic_dir,
+                install_tag: 'other',
                 rename: ['magic'],
             )
 
@@ -57,6 +60,7 @@ if build_application
         configuration: conf,
         install: true,
         install_dir: datadir / 'applications',
+        install_tag: 'other',
     )
 
     logos = [
@@ -80,6 +84,7 @@ if build_application
         install_data(
             meson.project_source_root() / 'assets' / 'icon' / logo,
             install_dir: datadir / 'icons' / 'hicolor' / name / 'apps',
+            install_tag: 'assets',
             rename: [app_name + '.' + ext],
         )
     endforeach

--- a/tools/installer/setup.nsi
+++ b/tools/installer/setup.nsi
@@ -129,14 +129,8 @@ Section "Core App" CoreApp
     ; install dynamic libraries
     SetOutPath "$INSTDIR"
 
-    ; install all dyanmic libraries
+    ; install all dynamic libraries
     File /r "${DYNAMIC_LIBRARIES_DIR}\*.dll"
-
-    ; TODO: this need to be installed automatically
-    File "${PROJECT_BUILD_DIR}\subprojects\SDL2_ttf-2.20.1\sdl2_ttf.dll"
-    File "${PROJECT_BUILD_DIR}\subprojects\SDL2_image-2.6.3\sdl2image.dll"
-    File "${PROJECT_BUILD_DIR}\subprojects\SDL2_mixer-2.6.2\sdl2mixer.dll"
-    File "${PROJECT_SOURCE_DIR}\subprojects\discord_game_sdk-3.2.1\lib\x86_64\discord_game_sdk.dll"
 
     ; install default settings (DO NOT Override)
     SetOutPath "$APPDATA\${AUTHOR}\${NAME}"

--- a/tools/installer/setup.nsi
+++ b/tools/installer/setup.nsi
@@ -18,6 +18,10 @@
 !error "PROJECT_BUILD_DIR not specified"
 !endif
 
+!ifndef DYNAMIC_LIBRARIES_DIR
+!error "DYNAMIC_LIBRARIES_DIR not specified"
+!endif
+
 !ifndef NAME
 !error "NAME not specified"
 !endif
@@ -125,26 +129,13 @@ Section "Core App" CoreApp
     ; install dynamic libraries
     SetOutPath "$INSTDIR"
 
-    ; install oopetris-* core libraries
-    File "${PROJECT_BUILD_DIR}\src\libs\core\oopetris_core-0.dll"
-    File "${PROJECT_BUILD_DIR}\src\libs\recordings\oopetris_recordings-0.dll"
-    File "${PROJECT_BUILD_DIR}\src\oopetris_graphics-0.dll"
+    ; install all dyanmic libraries
+    File /r "${DYNAMIC_LIBRARIES_DIR}\*.dll"
 
-    ; install subprojects / external libraries
-    File "${PROJECT_BUILD_DIR}\subprojects\SDL2-2.30.6\SDL2-6.dll"
-    File "${PROJECT_BUILD_DIR}\subprojects\fmt-11.0.2\fmt.dll"
+    ; TODO: this need to be installed automatically
     File "${PROJECT_BUILD_DIR}\subprojects\SDL2_ttf-2.20.1\sdl2_ttf.dll"
-    File "${PROJECT_BUILD_DIR}\subprojects\freetype-2.13.3\freetype-6.dll"
     File "${PROJECT_BUILD_DIR}\subprojects\SDL2_image-2.6.3\sdl2image.dll"
-    File "${PROJECT_BUILD_DIR}\subprojects\libpng-1.6.44\png16-16.dll"
     File "${PROJECT_BUILD_DIR}\subprojects\SDL2_mixer-2.6.2\sdl2mixer.dll"
-    File "${PROJECT_BUILD_DIR}\subprojects\libvorbis-1.3.7\lib\vorbisfile-3.dll"
-    File "${PROJECT_BUILD_DIR}\subprojects\libvorbis-1.3.7\lib\vorbis-0.dll"
-    File "${PROJECT_BUILD_DIR}\subprojects\libogg-1.3.5\src\ogg.dll"
-    File "${PROJECT_BUILD_DIR}\subprojects\flac-1.4.3\src\libFLAC\FLAC-8.dll"
-    File "${PROJECT_BUILD_DIR}\subprojects\openssl-3.0.8\crypto.dll"
-    File "${PROJECT_BUILD_DIR}\subprojects\openssl-3.0.8\ssl.dll"
-    File "${PROJECT_BUILD_DIR}\subprojects\nativefiledialog-extended-1.2.1\src\nativefiledialog-extended.dll"
     File "${PROJECT_SOURCE_DIR}\subprojects\discord_game_sdk-3.2.1\lib\x86_64\discord_game_sdk.dll"
 
     ; install default settings (DO NOT Override)


### PR DESCRIPTION
use the meson tagged install feature, to install all needed dynamic libraries 

TODO:
- [x] some shipped wraps don't support this yet, so this needs to be patched
   See https://github.com/mesonbuild/wrapdb/pull/1736 https://github.com/mesonbuild/wrapdb/pull/1738 https://github.com/mesonbuild/wrapdb/pull/1739
  - https://github.com/mesonbuild/wrapdb/pull/1737 was implemented locally, with a patch
- [x] not every install target has a tag, some have `null`, add one for all

also simplify the windows installer, by removing manual version numbers, and manual packaging of needed dynamic librarries