### PR TITLE
ci: use arm64 images

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -43,10 +43,18 @@ jobs:
             architecture: ucrt-x86_64
             shell: 'msys2 {0}'
 
+          - name: Linux (ARM64)
+            os: ubuntu
+            os-version: 24.04-arm
+            use-clang: false
+            arm: true
+            shell: bash
+
           - name: Linux
             os: ubuntu
             os-version: 24.04
             use-clang: false
+            arm: false
             shell: bash
 
           - name: Linux Clang (libstdc++)
@@ -54,6 +62,7 @@ jobs:
             os-version: 24.04
             use-clang: true
             use-clang_stdlib: false
+            arm: false
             shell: bash
 
           - name: Linux Clang (libc++)
@@ -61,6 +70,7 @@ jobs:
             os-version: 24.04
             use-clang: true
             use-clang_stdlib: true
+            arm: false
             shell: bash
 
           - name: MacOS

--- a/.github/workflows/flatpak.yml
+++ b/.github/workflows/flatpak.yml
@@ -11,37 +11,24 @@ on:
 jobs:
   flatpak:
     name: Flatpak build (${{ matrix.config.arch }})
-    runs-on: ubuntu-24.04
+    runs-on: ubuntu-${{ matrix.config.os-version }}
     strategy:
       matrix:
         config:
           - arch: x86_64
-            use_qemu: false
+            os-version: 24.04
 
           - arch: aarch64
-            use_qemu: true
-            qemu_arch: arm64
+            os-version: 24.04-arm
       # Don't fail the whole workflow if one architecture fails
       fail-fast: false
     container:
-      image: bilelmoussaoui/flatpak-github-actions:freedesktop-24.08
+      image: ghcr.io/flathub-infra/flatpak-github-actions:freedesktop-24.08
       options: --privileged
     steps:
       - uses: actions/checkout@v4
 
-      - name: Install deps
-        if: ${{ matrix.config.use_qemu == true }}
-        run: |
-          dnf -y install docker
-
-      - name: Set up QEMU
-        if: ${{ matrix.config.use_qemu == true }}
-        id: qemu
-        uses: docker/setup-qemu-action@v3
-        with:
-          platforms: ${{ matrix.config.qemu_arch }}
-
-      - uses: bilelmoussaoui/flatpak-github-actions/flatpak-builder@v6
+      - uses: flathub-infra/flatpak-github-actions/flatpak-builder@9386d85446c0f8c6b93dea3774002af2abcac3d5
         with:
           bundle: oopetris.flatpak
           manifest-path: io.github.openbrickprotocolfoundation.oopetris.yml


### PR DESCRIPTION
arm64 images are now in preview
see https://github.blog/changelog/2025-01-16-linux-arm64-hosted-runners-now-available-for-free-in-public-repositories-public-preview/

blocked by https://github.com/flatpak/flatpak-github-actions/pull/216

Already solved by https://github.com/flathub-infra/flatpak-github-actions


see https://github.com/flathub-infra/flatpak-github-actions/?tab=readme-ov-file#multi-arch-build-using-public-arm64-runners